### PR TITLE
Properly escape database name

### DIFF
--- a/docker/docker-entrypoint-initdb.d/20-create-app-db.sh
+++ b/docker/docker-entrypoint-initdb.d/20-create-app-db.sh
@@ -12,7 +12,7 @@ do
   psql -v ON_ERROR_STOP=1 \
       --dbname "$db" \
       --username="$user" <<-EOSQL
-      CREATE DATABASE ${database} OWNER ${app_user};
+      CREATE DATABASE "${database}" OWNER ${app_user};
 EOSQL
 done
 


### PR DESCRIPTION
To prevent errors like this 
![image](https://user-images.githubusercontent.com/29674758/89018054-e01f5300-d338-11ea-9189-242cfb5d8029.png)

