### PR TITLE
Update Docker image tag from :stable to :29

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:28
+FROM docker:29
 
 RUN set -eux ; \
     apk add  --no-cache bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:stable
+FROM docker:29
 
 RUN set -eux ; \
     apk add  --no-cache bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:29
+FROM docker:28
 
 RUN set -eux ; \
     apk add  --no-cache bash


### PR DESCRIPTION
Upgrades the Docker client image to ensure compatibility with modern Docker Engine versions.

Problem
The :stable tag uses an outdated Docker client (API 1.40) incompatible with Docker Engine v25+. This causes:
```
Error response from daemon: client version 1.40 is too old. Minimum supported API version is 1.44
```